### PR TITLE
Refactor : Use `ConfigurationException` instead of `RuntimeException` and other changes

### DIFF
--- a/src/main/java/th/ac/kmitl/science/comsci/example/ConfigurationInitServletContextListener.java
+++ b/src/main/java/th/ac/kmitl/science/comsci/example/ConfigurationInitServletContextListener.java
@@ -4,7 +4,9 @@ import th.ac.kmitl.science.comsci.example.utils.Configuration;
 
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
+import javax.servlet.annotation.WebListener;
 
+@WebListener
 public class ConfigurationInitServletContextListener implements ServletContextListener {
 
     @Override

--- a/src/main/java/th/ac/kmitl/science/comsci/example/utils/Configuration.java
+++ b/src/main/java/th/ac/kmitl/science/comsci/example/utils/Configuration.java
@@ -10,13 +10,13 @@ public class Configuration {
 
     public static Configuration getConfiguration() {
         if(configuration == null || !isInitialized)
-            throw new RuntimeException("Configuration must be initialized by calling Configuration.init() first");
+            throw new ConfigurationException("Configuration must be initialized by calling Configuration.init() first");
         return configuration;
     }
 
     public static void init(String configurationFile) {
         if(isInitialized)
-            throw new RuntimeException("Configuration is initialized.");
+            throw new ConfigurationException("Configuration is initialized.");
         configuration = new Configuration(configurationFile);
         isInitialized = true;
     }
@@ -29,13 +29,13 @@ public class Configuration {
             InputStream inputStream = classLoader.getResourceAsStream(configurationFile);
             properties.load(inputStream);
         } catch (IOException e) {
-            throw new RuntimeException(e.getMessage(), e.getCause());
+            throw new ConfigurationException(e.getMessage(), e.getCause());
         } catch (NullPointerException e) {
 
             // When configurationFile is not exist
             // classLoader.getResourceAsStream(configurationFile) will return null,
             // so inputStream can be null because of this behavior
-            throw new RuntimeException(e.getMessage(), e.getCause());
+            throw new ConfigurationException(e.getMessage(), e.getCause());
         }
     }
 
@@ -43,8 +43,12 @@ public class Configuration {
         return properties.getProperty(key);
     }
 
+    public static boolean isInitialized() {
+        return isInitialized;
+    }
+
     @Override
-    protected void finalize() throws Throwable {
+    public void finalize() throws Throwable {
         super.finalize();
         Configuration.configuration = null;
         Configuration.isInitialized = false;

--- a/src/main/java/th/ac/kmitl/science/comsci/example/utils/ConfigurationException.java
+++ b/src/main/java/th/ac/kmitl/science/comsci/example/utils/ConfigurationException.java
@@ -1,0 +1,12 @@
+package th.ac.kmitl.science.comsci.example.utils;
+
+public class ConfigurationException extends RuntimeException {
+
+    public ConfigurationException(String message) {
+        super(message);
+    }
+
+    public ConfigurationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/test/java/th/ac/kmitl/science/comsci/example/utils/ConfigurationTest.java
+++ b/src/test/java/th/ac/kmitl/science/comsci/example/utils/ConfigurationTest.java
@@ -12,20 +12,27 @@ public class ConfigurationTest {
     public final ExpectedException exception = ExpectedException.none();
 
     @Test
-    public void cannotGetInstanceWithoutInit() {
+    public void cannotGetInstanceWithoutInit() throws Throwable {
+        Configuration.getConfiguration().finalize();
+
         exception.expect(RuntimeException.class);
         Configuration configuration = Configuration.getConfiguration();
     }
 
     @Test
     public void canGetConfiguration() {
-        Configuration.init("junitconfig.properties");
+        if(!Configuration.isInitialized())
+            Configuration.init("junitconfig.properties");
+
         Configuration configuration = Configuration.getConfiguration();
         assertEquals("eTaxApp", configuration.getProperty("db.username"));
     }
 
     @Test
     public void cannotInitIfInitialized() {
+        if(!Configuration.isInitialized())
+            Configuration.init("junitconfig.properties");
+
         exception.expect(RuntimeException.class);
         Configuration.init("junitconfig.properties");
     }


### PR DESCRIPTION
Refactor to use `ConfigurationException` instead of `RuntimeException` to support fallback configuration if needed in the client code.
**Example**
```
try {
    Configuration.init(configurationFile);
} catch (ConfigurationException e) {
    Configuration.init(fallbackConfigurationFile);
}
```

Some Configuration-related test might be failed because of unpredictable test execution order so exposing `isInitialized` property and `finalize()` method should help when dealing with that. It should be helpful to the client code too.

Also annotate `@WebListener` to make sure that `ConfigurationInitServletContextListener` will load at servlet startup.